### PR TITLE
Added GetRegisters method on Zog

### DIFF
--- a/zog.go
+++ b/zog.go
@@ -201,6 +201,10 @@ func (z *Zog) LoadRegisters(reg Registers) {
 	z.reg = reg
 }
 
+func (z *Zog) GetRegisters() Registers {
+	return z.reg
+}
+
 func (z *Zog) LoadInterruptState(is InterruptState) {
 	z.is = is
 }


### PR DESCRIPTION
Hi, I was looking this Library and I saw there is no easy method to get the current registers of a Zog structure, so I added this method.